### PR TITLE
Migrate from dockerhub to Github Container Registry

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -2,17 +2,21 @@ name: CI Workflow
 
 on:
   push:
-
+    branches:
+      - dockerhub-to-ghcr
   release:
       types: [published]
 
 env:
   CI: true
-  DOCKERHUB_REPO: harrisonai/cobalt-purestorage-credentials-rotator
+  IMAGE_REPO: ghcr.io/harrison-ai/cobalt-purestorage-credentials-rotator
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -36,22 +40,23 @@ jobs:
         run: echo "SHORT_SHA=$(echo ${GITHUB_SHA} | cut -c1-8)" >> ${GITHUB_ENV}
         if: github.event_name != 'release'
 
-      - name: log into docker hub
+      - name: log into github container registry
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: publish docker image - non release
         run: make publish
         if: github.event_name == 'push'
         env:
-          IMAGE_NAME: ${{ env.DOCKERHUB_REPO }}
+          IMAGE_NAME: ${{ env.IMAGE_REPO }}
           IMAGE_TAG: ${{ env.SHORT_SHA }}
 
       - name: publish docker image - release
         run: make publish-release
         if: github.event_name == 'release'
         env:
-          IMAGE_NAME: ${{ env.DOCKERHUB_REPO }}
+          IMAGE_NAME: ${{ env.IMAGE_REPO }}
           IMAGE_TAG: ${{ github.ref_name }}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -2,8 +2,7 @@ name: CI Workflow
 
 on:
   push:
-    branches:
-      - dockerhub-to-ghcr
+
   release:
       types: [published]
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-IMAGE_NAME ?= harrisonai/cobalt-purestorage-credentials-rotator
+IMAGE_NAME ?= ghcr.io/harrison-ai/cobalt-purestorage-credentials-rotator
 IMAGE_TAG ?= $(shell git rev-parse HEAD | cut -c1-8)
 
 .EXPORT_ALL_VARIABLES:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    image: ${IMAGE_NAME:-harrisonai/cobalt-purestorage-credentials-rotator}:local
+    image: ${IMAGE_NAME:-ghcr.io/harrison-ai/cobalt-purestorage-credentials-rotator}:local
     entrypoint: []
     volumes:
       - './output:/output'
@@ -25,7 +25,7 @@ services:
       - rotate-fb-creds
 
   smoketest:
-    image: ${IMAGE_NAME:-harrisonai/cobalt-purestorage-credentials-rotator}:local
+    image: ${IMAGE_NAME:-ghcr.io/harrison-ai/cobalt-purestorage-credentials-rotator}:local
     entrypoint: []
     command:
       - smoketest


### PR DESCRIPTION
## Related Tasks

- https://github.com/harrison-ai/platform/issues/146

## What

- Push to Github Container Registry instead of dockerhub

Other steps:
- Make package public.
- Cut release 0.1.1.
- Update downstream https://github.com/harrison-ai/harrison-infra-hpc/pull/385/

## Why

- We are moving away from hosting on dockerhub

## Notes

- Successful action: https://github.com/harrison-ai/cobalt-purestorage-credential-rotator/actions/runs/4685957024/jobs/8303534865
- Package: https://github.com/harrison-ai/cobalt-purestorage-credential-rotator/pkgs/container/cobalt-purestorage-credentials-rotator